### PR TITLE
Optimize resolve_fw_decl

### DIFF
--- a/pytypes/util.py
+++ b/pytypes/util.py
@@ -22,6 +22,7 @@ Todo: Some functions in this module can be simplified or replaced
       by more consequent use of inspect module.
 """
 
+import functools
 import pytypes
 import subprocess
 import hashlib
@@ -691,6 +692,7 @@ def _code_matches_func(func, code):
                     return False
 
 
+@functools.lru_cache()
 def get_function_perspective_globals(module_name, level=0):
     globs = {}
     if not module_name is None:


### PR DESCRIPTION
This is a huge time-saver. Otherwise globals for `resolve_fw_decl` are being rebuild again and again our case, which just blows up. It brings 4 minutes loading time (we do some type checking at loading time) to 14 seconds.

See crazy slow trace [here](https://gist.github.com/remram44/455bfd4d95bf6af15fe5c11114cc0369).

So `resolve_fw_decl` calls `get_function_perspective_globals` which then calls `getframeinfo` 53240 times which calls `getmodule` 81927 times and this is just slow. In our case cache has just 8 entries (I left it to default 128) at the end for this speedup:

```
CacheInfo(hits=1414, misses=8, maxsize=128, currsize=8)
```