### PR TITLE
Fix wrong assertion in typlogger.combined_argtype.

### DIFF
--- a/pytypes/typelogger.py
+++ b/pytypes/typelogger.py
@@ -146,7 +146,7 @@ def combine_argtype(observations):
     additional unification effort (e.g. can apply PEP 484 style numeric tower).
     """
     assert len(observations) > 0
-    assert isinstance(is_Tuple(observations[0]))
+    assert is_Tuple(observations[0])
     if len(observations) > 1:
         prms = [get_Tuple_params(observations[0])]
         ln = len(prms[0])

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -4734,5 +4734,38 @@ class Test_utils(unittest.TestCase):
         self.assertFalse(pytypes.is_subtype(list, Wrapper))
 
 
+class Test_combine_argtype(unittest.TestCase):
+    def test_exceptions(self):
+        # Empty observations not allowed
+        with self.assertRaises(AssertionError):
+            pytypes.typelogger.combine_argtype([])
+
+        # Non tuple types not allowed
+        with self.assertRaises(AssertionError):
+            notTuple = typing.List[int]
+            pytypes.typelogger.combine_argtype([notTuple])
+
+        with self.assertRaises(AssertionError):
+            notTuple = typing.List[int]
+            pytypes.typelogger.combine_argtype([typing.Tuple[int], notTuple])
+
+    def test_function(self):
+        # If single observation is supplied it should return itself
+        self.assertEqual(
+            pytypes.typelogger.combine_argtype([typing.Tuple[int]]),
+            typing.Tuple[int],
+        )
+        # Observations should be unioned
+        self.assertEqual(
+            pytypes.typelogger.combine_argtype([typing.Tuple[int], typing.Tuple[str]]),
+            typing.Tuple[typing.Union[int, str]],
+        )
+        # Number classes should be combined as PEP 484 style numeric tower
+        self.assertEqual(
+            pytypes.typelogger.combine_argtype([typing.Tuple[int], typing.Tuple[float]]),
+            typing.Tuple[float],
+        )
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #46

I also threw in few test cases for `combine_argtype` just in case.

Feel free to remove it if you deem it unnecessary.