### PR TITLE
Fixed infinite recursion when pytypes tries to access  .__orig_class__ on an instance of a @typechecked class with __getattr__/__getattribute__

### DIFF
--- a/pytypes/typechecker.py
+++ b/pytypes/typechecker.py
@@ -33,7 +33,7 @@ from .util import getargspecs, _actualfunc
 from .type_util import type_str, has_type_hints, _has_type_hints, is_builtin_type, \
         deep_type, _funcsigtypes, _issubclass, _isinstance, _find_typed_base_method, \
         _preprocess_typecheck, _raise_typecheck_error, _check_caller_type, TypeAgent, \
-        _check_as_func, is_Tuple
+        _check_as_func, is_Tuple, _get_orig_class
 from . import util, type_util
 
 try:
@@ -796,7 +796,7 @@ def _typeinspect_func(func, do_typecheck, do_logging, \
         parent_class = None
         if slf:
             try:
-                parent_class = args_kw[0].__orig_class__
+                parent_class = _get_orig_class(args_kw[0])
             except AttributeError:
                 parent_class = args_kw[0].__class__
         elif clsm:

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -2591,6 +2591,12 @@ class TestTypecheck_class(unittest.TestCase):
 
 
 class TestTypecheck_class_with_getattr(unittest.TestCase):
+    """
+    See pull request:
+    https://github.com/Stewori/pytypes/pull/53
+    commit #:
+    e2523b347e52707f87d7078daad1a93940c12e2e
+    """
     def test_valid_access(self):
         obj = GetAttrDictWrapper({'a': 5, 'b': 10})
         self.assertEqual(obj.a, 5)

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -1370,6 +1370,38 @@ class B_auto_override_err(A_auto_override):
         return 3*len(c)
 
 
+@typechecked
+class GetAttrDictWrapper(object):
+    """Test a plausible use of __getattr__ -
+    A class that wraps a dict, enabling the values to be accessed as if they were attributes
+    (`d.abc` instead of `d['abc']`)
+    For example, the `pyrsistent` library does this on its dict replacement.
+
+    >>> o = GetAttrDictWrapper({'a': 5, 'b': 10})
+    >>> o.a
+    5
+    >>> o.b
+    10
+    >>> o.nonexistent
+    Traceback (most recent call last):
+      ...
+    AttributeError('nonexistent')
+    
+    """
+
+    def __init__(self, dct):
+        # type: (dict) -> None
+        self.__dct = dct
+
+    def __getattr__(self, attr):
+        # type: (str) -> typing.Any
+        dct = self.__dct # can safely access the attribute because it exists so it won't trigger __getattr__
+        try:
+            return dct[attr]
+        except KeyError:
+            raise AttributeError(attr)
+
+
 class TestTypecheck(unittest.TestCase):
     def test_function(self):
         self.assertEqual(testfunc(3, 2.5, 'abcd'), (9, 7.5))
@@ -2556,6 +2588,17 @@ class TestTypecheck_class(unittest.TestCase):
         self.assertEqual(tc.testmeth_static2(11, 1.9), '11-1.9-static')
         self.assertRaises(InputTypeError, lambda:
                 tc.testmeth_static2(11, ('a', 'b'), 1.9))
+
+
+class TestTypecheck_class_with_getattr(unittest.TestCase):
+    def test_valid_access(self):
+        obj = GetAttrDictWrapper({'a': 5, 'b': 10})
+        self.assertEqual(obj.a, 5)
+        self.assertEqual(obj.b, 10)
+
+    def test_invalid_access(self):
+        obj = GetAttrDictWrapper({'a': 5, 'b': 10})
+        self.assertRaises(AttributeError, lambda: obj.nonexistent)
 
 
 class TestTypecheck_module(unittest.TestCase):


### PR DESCRIPTION
Hi! I hit this problem yesterday and dived in to fix it because I was excited to use `pytypes` in my library :)
My environment is Python 3.5 running inside `pipenv` on Windows, and a fresh install of `pytypes==1.0b5.post2+dirty`.

Here's a simple case that should demonstrate the problematic behavior:
```python
from pytypes import typechecked

@typechecked
class Bad:
    def __getattr__(self, attr: str):
        if attr == 'one':
            return 1
        else:
            raise AttributeError(attr)

bad = Bad()
res = bad.one  # causes infinite recursion into the wrapped `__getattr__`
```
> *If, like me, you keep mixing up `__getattr__`/`__getattribute__`,
`__getattr__` is the one that acts like a fallback –
it's only called if other methods of attribute lookup failed:*
> *- the attr wasn't in the instance dict*
> *- there's a descriptor for the attr in the class dict but it raised AttributeError*
> *- the attr wasn't in the class dict either*

On an unwrapped class, `bad.one` would result in `Thing.__getattr__(bad, 'one')` and work fine.
When wrapped with `@typechecked`, it becomes be `Thing.checker_tp<__getattr__>(bad, 'one')`, where `checker_tp<__getattr__>` is the `checker_tp` (from `pytypes.typechecker._typinspect_func`) that wraps `__getattr__`.
Unfortunately, in its code, `checker_tp<__getattr__>` does this:
```python
try:
    parent_class = args_kw[0].__orig_class__
except AttributeError:
    ...
```
We're in a method call, so `args_kw[0]` is `self` – our `bad` object. But `bad.__orig_class__` – a dot-access on a nonexistent attribute – ends up calling `checker_tp<__getattr__>(bad, '__orig_class__')` again, which tries to get the `__orig_class__` again, and so on until it hits a `RecursionError`.

The way I solve this in this pull request is simple –
**Use `object.__getattribute__(x, '__orig_class__')` instead**, thus bypassing a classes' `__getattr__` and `__getattribute__`. I'm not familiar with `pytypes`' internals, So I don't know what consequences this could have; I imagine it *might* lead to unexpected behaviour on proxy-like classes.

Ideas for alternative solutions (FWIW from a person unfamiliar with the code):

- **Wrap `__getattr__`/`__getattribute__`, but special-case them somehow** so that `pytypes` internals know they should use the unwrapped version instead. I'm pretty fuzzy on the details, but it seems plausible. 

- **Don't wrap `__getattr__`/`__getattribute__` at all.**
Unfortunately if the original `__getattr[ibute]__` returns a method, an un-wrapped method would 'leak' out. But I guess this could happen with any method, so maybe it's not a solvable problem anyway.
(I guess in that case `pytypes` could do identity checks with known methods from the class __dict__, and returning the appropriate wrapped method instead if possible. But that'd require wrapping `__getattr[ibute]__`, which we're trying to avoid.)

I hope this wasn't too long winded. Please tell me what you think about this solution!