### PR TITLE
Issue #89: add tests for partial annotations.

### DIFF
--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -4508,6 +4508,35 @@ class TestTypecheck_Python3_5(unittest.TestCase):
 
         pytypes.infer_default_value_types = tmp
 
+    def test_defaults_with_missing_annotations_plain(self):
+        # See: https://github.com/Stewori/pytypes/issues/89
+        helper = py3.method_defaults_typecheck()
+        self.assertEqual(helper.plain_method(1), 1)
+        self.assertEqual(helper.plain_method(1, 2), 3)
+        self.assertRaises(InputTypeError, lambda: helper.plain_method(1, 'b'))
+
+    def test_defaults_with_missing_annotations_class(self):
+        # See: https://github.com/Stewori/pytypes/issues/89
+        helper = py3.method_defaults_typecheck()
+        self.assertEqual(helper.class_method(1), 1)
+        self.assertEqual(helper.class_method(1, 2), 3)
+        self.assertRaises(InputTypeError, lambda: helper.class_method(1, 'b'))
+
+    def test_defaults_with_missing_annotations_property(self):
+        # See: https://github.com/Stewori/pytypes/issues/89
+        helper = py3.method_defaults_typecheck()
+        self.assertEqual(helper.property_method, 0)
+        helper.property_method = 1
+        self.assertEqual(helper.property_method, 2)
+
+    def test_defaults_with_missing_annotations_static(self):
+        # See: https://github.com/Stewori/pytypes/issues/89
+        # Just being thorough (staticmethod already worked before fixing #89)
+        helper = py3.method_defaults_typecheck()
+        self.assertEqual(helper.static_method(1), 1)
+        self.assertEqual(helper.static_method(1, 2), 3)
+        self.assertRaises(InputTypeError, lambda: helper.static_method(1, 'b'))
+
     def test_typecheck_parent_type(self):
         always_check_parent_types_tmp = pytypes.always_check_parent_types
         pytypes.always_check_parent_types = False

--- a/tests/testhelpers/typechecker_testhelper_py3.py
+++ b/tests/testhelpers/typechecker_testhelper_py3.py
@@ -789,6 +789,30 @@ def func_defaults_annotations(a: str, b, c=4) -> str:
     b = 'abc'
     return a+b*c
 
+@typechecked
+class method_defaults_typecheck(object):
+    value = 0
+
+    def plain_method(self, a, b: int = 0) -> int:
+        return a+b
+
+    @classmethod
+    def class_method(cls, a, b: int = 0) -> int:
+        return a+b
+
+    @property
+    def property_method(self, a = 0, b: int = 0) -> int:
+        return self.value+a+b
+
+    @property_method.setter
+    def property_method(self, a, b: int = 1) -> None:
+        self.value = a+b
+
+    @staticmethod
+    def static_method(a, b: int = 0) -> int:
+        return a+b
+
+
 class override_varargs_class_base(object):
 # var-arg tests:
     def method_vararg1(self, a: int, b: int, *args: int) -> int:


### PR DESCRIPTION
Three of these tests fail. The fourth (staticmethod) is there for completeness. In typing this, I realise I never tested a property deleter. But I was already stretching credibility, testing property getters and setters with default parameters, since you can't pass values for them via attribute access.

All tests pass with `pytypes.infer_default_value_types = False`.

The assertRaises calls are just there so that these tests don't consider "enforce nothing" to be a valid fix.
