### PR TITLE
Delete conditional imports for backports.typing

### DIFF
--- a/pytypes/__init__.py
+++ b/pytypes/__init__.py
@@ -303,10 +303,7 @@ try:
 except ImportError:
     pass
 
-try:
-    from backports import typing
-except ImportError:
-    import typing
+import typing
 
 typing_3_7 = False
 try:

--- a/pytypes/stubfile_2_converter.py
+++ b/pytypes/stubfile_2_converter.py
@@ -44,10 +44,7 @@ except ImportError:
 import pytypes
 from pytypes import util, typelogger, type_util
 
-try:
-    from backports.typing import Any, TypeVar
-except ImportError:
-    from typing import Any, TypeVar
+from typing import Any, TypeVar
 
 
 py3 = False

--- a/pytypes/stubfile_manager.py
+++ b/pytypes/stubfile_manager.py
@@ -23,10 +23,7 @@ import sys
 import tempfile
 import warnings
 from inspect import isclass, ismodule, ismethod
-try:
-    from backports.typing import Union, Tuple, Callable
-except ImportError:
-    from typing import Union, Tuple, Callable
+from typing import Union, Tuple, Callable
 
 import pytypes
 from pytypes import util

--- a/pytypes/type_util.py
+++ b/pytypes/type_util.py
@@ -22,14 +22,9 @@ import typing
 import collections
 import weakref
 from inspect import isfunction, ismethod, isclass, ismodule, stack
-try:
-    from backports.typing import Tuple, Dict, List, Set, FrozenSet, Union, Any, \
-            Sequence, Mapping, TypeVar, Container, Generic, Sized, Iterable, Iterator, \
-            Generator, T_co, V_co, VT_co, T_contra, KT, T, VT
-except ImportError:
-    from typing import Tuple, Dict, List, Set, FrozenSet, Union, Any, \
-            Sequence, Mapping, TypeVar, Container, Generic, Sized, Iterable, Iterator, \
-            Generator, T_co, V_co, VT_co, T_contra, KT, T, VT
+from typing import Tuple, Dict, List, Set, FrozenSet, Union, Any, \
+        Sequence, Mapping, TypeVar, Container, Generic, Sized, Iterable, Iterator, \
+        Generator, T_co, V_co, VT_co, T_contra, KT, T, VT
 
 import pytypes
 _typing_3_7 = pytypes.typing_3_7

--- a/pytypes/typechecker.py
+++ b/pytypes/typechecker.py
@@ -23,6 +23,7 @@ import inspect
 import re as _re
 import sys
 import types
+import typing
 import collections
 from inspect import isclass, ismodule, isfunction, ismethod, ismethoddescriptor
 from warnings import warn
@@ -36,11 +37,6 @@ from .type_util import type_str, has_type_hints, _has_type_hints, is_builtin_typ
         _preprocess_typecheck, _raise_typecheck_error, _check_caller_type, TypeAgent, \
         _check_as_func, is_Tuple, get_orig_class
 from . import util, type_util
-
-try:
-    from backports import typing
-except ImportError:
-    import typing
 
 if sys.version_info.major >= 3:
     import builtins

--- a/pytypes/typecomment_parser.py
+++ b/pytypes/typecomment_parser.py
@@ -15,14 +15,10 @@
 # Created on 13.12.2016
 
 import inspect, typing
+from typing import Any, Tuple
 
 import pytypes
 from .exceptions import TypeSyntaxError
-
-try:
-    from backports.typing import Any, Tuple
-except ImportError:
-    from typing import Any, Tuple
 
 
 def _striptrailingcomment(s):

--- a/pytypes/typelogger.py
+++ b/pytypes/typelogger.py
@@ -26,6 +26,7 @@ import os
 import abc
 import datetime
 import atexit
+from typing import Union, Any, Tuple
 from inspect import getmembers, isclass, ismodule, getsourcelines, \
         findsource, isfunction, ismethod, ismethoddescriptor
 
@@ -33,11 +34,6 @@ try:
     import pkg_resources
 except ImportError:
     pass
-
-try:
-    from backports.typing import Union, Any, Tuple
-except ImportError:
-    from typing import Union, Any, Tuple
 
 import pytypes
 from .type_util import deep_type, type_str, get_Tuple_params, \

--- a/tests/test_typechecker.py
+++ b/tests/test_typechecker.py
@@ -28,15 +28,10 @@ from pytypes import typechecked, override, auto_override, no_type_check, get_typ
     TypeChecker, restore_profiler, is_subtype, is_of_type, type_bases
     
 pytypes.clean_traceback = False
-try:
-    from backports import typing
-    from backports.typing import Tuple, List, Union, Any, Dict, Generator, TypeVar, Generic, \
-        Iterable, Iterator, Sequence, Callable, Mapping, Set
-except ImportError:
-    import typing
-    from typing import Tuple, List, Union, Any, Dict, Generator, TypeVar, Generic, Iterable, \
-        Iterator, Sequence, Callable, Mapping, Set, Optional, \
-        T_co, V_co, VT_co, T_contra, KT, T, VT
+import typing
+from typing import Tuple, List, Union, Any, Dict, Generator, TypeVar, Generic, Iterable, \
+    Iterator, Sequence, Callable, Mapping, Set, Optional, \
+    T_co, V_co, VT_co, T_contra, KT, T, VT
 
 pytypes.check_override_at_class_definition_time = False
 pytypes.check_override_at_runtime = True

--- a/tests/testhelpers/modulewide_typecheck_testhelper.py
+++ b/tests/testhelpers/modulewide_typecheck_testhelper.py
@@ -15,12 +15,8 @@
 # Created on 29.01.2017
 
 from pytypes import override
-try:
-    from backports.typing import Tuple, Union, Mapping, Dict, Generator, TypeVar, Generic, \
-            Iterable, Iterator, Sequence, Callable, List, Any
-except ImportError:
-    from typing import Tuple, Union, Mapping, Dict, Generator, TypeVar, Generic, \
-            Iterable, Iterator, Sequence, Callable, List, Any
+from typing import Tuple, Union, Mapping, Dict, Generator, TypeVar, Generic, \
+        Iterable, Iterator, Sequence, Callable, List, Any
 import abc; from abc import abstractmethod
 from numbers import Real
 

--- a/tests/testhelpers/modulewide_typecheck_testhelper_py2.py
+++ b/tests/testhelpers/modulewide_typecheck_testhelper_py2.py
@@ -16,12 +16,8 @@
 
 from pytypes import override, no_type_check
 
-try:
-    from backports import typing; from backports.typing import Tuple, List, Union, Any, \
-            Dict, Generator, TypeVar, Generic, Iterable, Iterator, Sequence, Callable, Mapping
-except ImportError:
-    import typing; from typing import Tuple, List, Union, Any, Dict, Generator, TypeVar, \
-            Generic, Iterable, Iterator, Sequence, Callable, Mapping
+import typing; from typing import Tuple, List, Union, Any, Dict, Generator, TypeVar, \
+        Generic, Iterable, Iterator, Sequence, Callable, Mapping
 from numbers import Real
 import abc; from abc import abstractmethod
 

--- a/tests/testhelpers/stub_testhelper.py
+++ b/tests/testhelpers/stub_testhelper.py
@@ -15,12 +15,7 @@
 # Created on 21.10.2016
 
 from pytypes import typechecked, check_argument_types, annotations, override
-
-try:
-    from backports.typing import Generic, TypeVar
-except ImportError:
-    from typing import Generic, TypeVar
-
+from typing import Generic, TypeVar
 
 @typechecked
 def testfunc1(a, b):

--- a/tests/testhelpers/stub_testhelper.pyi
+++ b/tests/testhelpers/stub_testhelper.pyi
@@ -14,14 +14,9 @@
 
 # Created on 21.10.2016
 
+from typing import Any, TypeVar, Generic, Generator, Iterable, Sequence, \
+        Tuple, List, Callable, Dict, Mapping, Union
 from numbers import Real
-
-try:
-    from backports.typing import Any, TypeVar, Generic, Generator, Iterable, Sequence, \
-            Tuple, List, Callable, Dict, Mapping, Union
-except ImportError:
-    from typing import Any, TypeVar, Generic, Generator, Iterable, Sequence, \
-            Tuple, List, Callable, Dict, Mapping, Union
 
 def testfunc1(a: int, b: Real) -> str: ...
 

--- a/tests/testhelpers/stub_testhelper_py2.py
+++ b/tests/testhelpers/stub_testhelper_py2.py
@@ -15,11 +15,7 @@
 # Created on 08.11.2016
 
 from pytypes import typechecked, check_argument_types, annotations, override
-
-try:
-    from backports.typing import Generic, TypeVar
-except ImportError:
-    from typing import Generic, TypeVar
+from typing import Generic, TypeVar
 
 @typechecked
 def testfunc1_py2(a, b):

--- a/tests/testhelpers/stub_testhelper_py2.pyi
+++ b/tests/testhelpers/stub_testhelper_py2.pyi
@@ -14,14 +14,9 @@
 
 # Created on 08.11.2016
 
+from typing import Any, TypeVar, Generic, Generator, Iterable, Sequence, \
+        Tuple, List, Callable, Dict, Mapping, Union
 from numbers import Real
-
-try:
-    from backports.typing import Any, TypeVar, Generic, Generator, Iterable, Sequence, \
-            Tuple, List, Callable, Dict, Mapping, Union
-except ImportError:
-    from typing import Any, TypeVar, Generic, Generator, Iterable, Sequence, \
-            Tuple, List, Callable, Dict, Mapping, Union
 
 def testfunc1_py2(a, b):
     # type: (int, Real) -> str

--- a/tests/testhelpers/typechecker_testhelper_py3.py
+++ b/tests/testhelpers/typechecker_testhelper_py3.py
@@ -21,12 +21,7 @@ from numbers import Real
 import pytypes
 import testhelpers
 from pytypes import typechecked, override, check_argument_types, auto_override
-
-try:
-    from backports.typing import Tuple, Union, Mapping, Dict, Generator, TypeVar, Generic, \
-        Iterable, Iterator, Sequence, Callable, List, Any
-except ImportError:
-    from typing import Tuple, Union, Mapping, Dict, Generator, TypeVar, Generic, Iterable, \
+from typing import Tuple, Union, Mapping, Dict, Generator, TypeVar, Generic, Iterable, \
         Iterator, Sequence, Callable, List, Any, Optional
 
 


### PR DESCRIPTION
This backports.typing package has been deleted by the author, so the imports will just always fail and cause unnecessary clutter/complexity.

Fixes #93.